### PR TITLE
Visual Tweaks: Default black background and brighter text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -77,3 +77,4 @@
 
 == 0.x.x (xx.xx.xxxx):
 - Changed some display colors to be a bit brighter
+- Force terminal background color to be black

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -74,3 +74,6 @@
 == 0.6.3 (15.11.2015):
 - Fixed possible memory leak in backend.
 - Fixed possible SEGFAULT when new client appears.
+
+== 0.x.x (xx.xx.xxxx):
+- Changed some display colors to be a bit brighter

--- a/src/frontend.mm
+++ b/src/frontend.mm
@@ -43,8 +43,8 @@ static NSMutableArray *allWidgets;
     init_pair(2, -1, COLOR_GREEN); // low level volume/not muted
     init_pair(3, -1, COLOR_YELLOW); // medium level volume
     init_pair(4, -1, COLOR_RED); // high level volume/muted
-    init_pair(5, COLOR_BLACK, COLOR_MAGENTA); // extreme (>100%) level volume
-    init_pair(6, COLOR_BLACK, COLOR_BLUE); // outside mode
+    init_pair(5, COLOR_WHITE, COLOR_MAGENTA); // extreme (>100%) level volume
+    init_pair(6, COLOR_WHITE, COLOR_BLUE); // outside mode
     init_pair(7, COLOR_BLACK, COLOR_WHITE); // inside mode
     refresh();
     int my;

--- a/src/frontend.mm
+++ b/src/frontend.mm
@@ -38,7 +38,7 @@ static NSMutableArray *allWidgets;
     keypad(stdscr, TRUE);
     start_color();
     use_default_colors();
-    // default background/foreground (COLOR_PAIR(0) doesn't seem to work)
+    assume_default_colors(COLOR_WHITE, COLOR_BLACK);
     init_pair(1, -1, -1);
     init_pair(2, -1, COLOR_GREEN); // low level volume/not muted
     init_pair(3, -1, COLOR_YELLOW); // medium level volume


### PR DESCRIPTION
Here's a couple of commits which do some minor visual tweaks.

1) Default black background.  A simple call to `assume_default_colors(COLOR_WHITE, COLOR_BLACK);` takes care of that.  (Helpful for me because my default xterm background is white)

2) Brighten up the text in a few cases.  Right now the text color for some highlighted areas is COLOR_BLACK, but in my opinion it looks better as COLOR_WHITE; I don't have to strain to read the labels.  This is pretty subjective, of course.  Specifically, here's some screenshots:

Stock version: 

![pacmixer-before](https://user-images.githubusercontent.com/443343/27039861-d940c9b2-4f54-11e7-9cef-a9f047dc97b4.png)

After patch:

![pacmixer-after](https://user-images.githubusercontent.com/443343/27039866-deef419a-4f54-11e7-9257-71fe1ef41892.png)

As I say, personally I find the bottom one to be much more readable.