### PR TITLE
Add missing format string

### DIFF
--- a/src/widgets/notice.m
+++ b/src/widgets/notice.m
@@ -49,7 +49,7 @@
 -(void) print {
     wattron(win, A_REVERSE);
     box(win, 0, 0);
-    mvwprintw(win, 1, 1, [message UTF8String]);
+    mvwprintw(win, 1, 1, "%s", [message UTF8String]);
     wattroff(win, A_REVERSE);
 }
 

--- a/src/widgets/notice.m
+++ b/src/widgets/notice.m
@@ -49,7 +49,7 @@
 -(void) print {
     wattron(win, A_REVERSE);
     box(win, 0, 0);
-    mvwprintw(win, 1, 1, "%s", [message UTF8String]);
+    mvwprintw(win, 1, 1, "%@", message);
     wattroff(win, A_REVERSE);
 }
 


### PR DESCRIPTION
I don't actually know Objective C but the other day I tried updating `pacmixer` and it ended up deleting the binary and I could not live without this so I found what was breaking it for me. 

From a C perspective (i.e. ignoring the Objective-C syntax and other specifics) the issue makes sense; `mvwprintw` takes in a C string as a format string, but only a `UTF8String` was provided. Just adding `"%s"` as an argument so that the `message` value can be taken in works.